### PR TITLE
Support Sketch 66

### DIFF
--- a/src/framework/print-export/PESketchMethods.m
+++ b/src/framework/print-export/PESketchMethods.m
@@ -17,11 +17,23 @@
 
 + (NSData *)imageDataOfLayer:(MSImmutableLayer *)layer scale:(double)scale documentData:(MSImmutableDocumentData *)documentData {
     Class cls = NSClassFromString(kMSImmutableLayerAncestry);
-    MSImmutableLayerAncestry * layerAncestry = [cls alloc];
-    SEL selector = NSSelectorFromString(@"initWithLayer:ancestors:document:");
-    typedef MSImmutableLayerAncestry* (*MethodType1)(MSImmutableLayerAncestry *, SEL, MSImmutableLayer *, NSArray *, MSImmutableDocumentData *);
-    MethodType1 method1 = (MethodType1)[layerAncestry methodForSelector:selector];
-    layerAncestry = method1(layerAncestry, selector, layer, @[], documentData);
+    SEL selector;
+    MSImmutableLayerAncestry * layerAncestry;
+    if (cls == nil) {
+        // Sketch 66
+        cls = NSClassFromString(kMSImmutableLayerAncestry66);
+        layerAncestry = [cls alloc];
+        selector = NSSelectorFromString(@"initWithLayer:ancestors:document:");
+        typedef MSImmutableLayerAncestry* (*MethodType1)(MSImmutableLayerAncestry *, SEL, MSImmutableLayer *, NSArray *, MSImmutableDocumentData *);
+        MethodType1 method1 = (MethodType1)[layerAncestry methodForSelector:selector];
+        layerAncestry = method1(layerAncestry, selector, layer, @[], documentData);
+    } else {
+        layerAncestry = [cls alloc];
+        selector = NSSelectorFromString(@"initWithLayer:document:");
+        typedef MSImmutableLayerAncestry* (*MethodType1)(MSImmutableLayerAncestry *, SEL, MSImmutableLayer *, MSImmutableDocumentData *);
+        MethodType1 method1 = (MethodType1)[layerAncestry methodForSelector:selector];
+        layerAncestry = method1(layerAncestry, selector, layer, documentData);
+    }
 
     selector = NSSelectorFromString(@"formatWithScale:name:fileFormat:");
     typedef id (*MethodType2)(Class, SEL, double, NSString *, NSString *);

--- a/src/framework/print-export/PESketchMethods.m
+++ b/src/framework/print-export/PESketchMethods.m
@@ -18,17 +18,17 @@
 + (NSData *)imageDataOfLayer:(MSImmutableLayer *)layer scale:(double)scale documentData:(MSImmutableDocumentData *)documentData {
     Class cls = NSClassFromString(kMSImmutableLayerAncestry);
     MSImmutableLayerAncestry * layerAncestry = [cls alloc];
-    SEL selector = NSSelectorFromString(@"initWithLayer:document:");
-    typedef MSImmutableLayerAncestry* (*MethodType1)(MSImmutableLayerAncestry *, SEL, MSImmutableLayer *, MSImmutableDocumentData *);
+    SEL selector = NSSelectorFromString(@"initWithLayer:ancestors:document:");
+    typedef MSImmutableLayerAncestry* (*MethodType1)(MSImmutableLayerAncestry *, SEL, MSImmutableLayer *, NSArray *, MSImmutableDocumentData *);
     MethodType1 method1 = (MethodType1)[layerAncestry methodForSelector:selector];
-    layerAncestry = method1(layerAncestry, selector, layer, documentData);
-    
+    layerAncestry = method1(layerAncestry, selector, layer, @[], documentData);
+
     selector = NSSelectorFromString(@"formatWithScale:name:fileFormat:");
     typedef id (*MethodType2)(Class, SEL, double, NSString *, NSString *);
     cls = NSClassFromString(kMSExportFormat);
     MethodType2 method2 = (MethodType2)[cls methodForSelector:selector];
     id exportFormat = method2(cls, selector, scale, @"", @"png");
-    
+
     selector = NSSelectorFromString(@"exportRequestsFromLayerAncestry:exportFormats:");
     typedef NSArray * (*MethodType3)(Class, SEL, MSImmutableLayerAncestry *, NSArray *);
     cls = NSClassFromString(kMSExportRequest);
@@ -36,14 +36,14 @@
     NSArray *exportRequests = method3(cls, selector, layerAncestry, @[exportFormat]);
     MSExportRequest *exportRequest = exportRequests.firstObject;
     [exportRequest setValue:[NSNumber numberWithBool:YES] forKey:@"includeArtboardBackground"];
-    
+
     cls = NSClassFromString(kMSExportManager);
     MSExportManager *exportManager = [cls alloc];
     selector = NSSelectorFromString(@"init");
     typedef MSExportManager* (*MethodType4)(MSExportManager *, SEL);
     MethodType4 method4 = (MethodType4)[exportManager methodForSelector:selector];
     exportManager = method4(exportManager, selector);
-    
+
     selector = NSSelectorFromString(@"exportedDataForRequest:");
     typedef NSData * (*MethodType5)(MSExportManager *, SEL, MSExportRequest *);
     MethodType5 method5 = (MethodType5)[exportManager methodForSelector:selector];

--- a/src/framework/print-export/Sketch/MSConstants.h
+++ b/src/framework/print-export/Sketch/MSConstants.h
@@ -9,6 +9,7 @@
 #import <Foundation/Foundation.h>
 
 extern NSString *const kMSImmutableLayerAncestry;
+extern NSString *const kMSImmutableLayerAncestry66;
 extern NSString *const kMSExportFormat;
 extern NSString *const kMSExportRequest;
 extern NSString *const kMSExportManager;

--- a/src/framework/print-export/Sketch/MSConstants.m
+++ b/src/framework/print-export/Sketch/MSConstants.m
@@ -8,7 +8,7 @@
 
 #import "MSConstants.h"
 
-NSString *const kMSImmutableLayerAncestry = @"MSImmutableLayerAncestry";
+NSString *const kMSImmutableLayerAncestry = @"SketchModel.MSImmutableLayerAncestry";
 NSString *const kMSExportFormat = @"MSExportFormat";
 NSString *const kMSExportRequest = @"MSExportRequest";
 NSString *const kMSExportManager = @"MSExportManager";

--- a/src/framework/print-export/Sketch/MSConstants.m
+++ b/src/framework/print-export/Sketch/MSConstants.m
@@ -8,7 +8,8 @@
 
 #import "MSConstants.h"
 
-NSString *const kMSImmutableLayerAncestry = @"SketchModel.MSImmutableLayerAncestry";
+NSString *const kMSImmutableLayerAncestry = @"MSImmutableLayerAncestry";
+NSString *const kMSImmutableLayerAncestry66 = @"SketchModel.MSImmutableLayerAncestry";
 NSString *const kMSExportFormat = @"MSExportFormat";
 NSString *const kMSExportRequest = @"MSExportRequest";
 NSString *const kMSExportManager = @"MSExportManager";


### PR DESCRIPTION
Closes #25 

MSImmutableLayerAncestry was ported to Swift in Sketch 66.